### PR TITLE
Automatically inject Supabase config via `npm run dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ SoundDocs is a modern web application designed for audio engineers to create pro
 ## ✨ Features
 
 ### Core Functionality
-- **Patch Sheet Editor**  
+
+- **Patch Sheet Editor**
   Document input/output lists, signal flow, equipment specs, and technical notes
-- **Stage Plot Designer**  
+- **Stage Plot Designer**
   Create visual stage layouts with draggable elements (instruments, mics, monitors)
-- **Smart Export System**  
+- **Smart Export System**
   Generate high-quality PNG/PDF exports with dark/light mode options
-- **Collaboration Tools**  
+- **Collaboration Tools**
   Share documents via secure links with clients and crew
 
 ### Professional Features
+
 - Customizable templates for different venue sizes
 - Auto-save functionality with version history
 - Equipment database with common audio gear presets
@@ -31,6 +33,7 @@ SoundDocs is a modern web application designed for audio engineers to create pro
 ## 🛠️ Tech Stack
 
 ### Frontend
+
 - **Framework**: React 18 + TypeScript
 - **Build Tool**: Vite
 - **Styling**: Tailwind CSS + CSS Modules
@@ -40,6 +43,7 @@ SoundDocs is a modern web application designed for audio engineers to create pro
 - **PDF/Image Export**: html2canvas
 
 ### Backend
+
 - **Authentication**: Supabase Auth
 - **Database**: Supabase PostgreSQL
 - **Real-time Updates**: Supabase Realtime
@@ -48,10 +52,12 @@ SoundDocs is a modern web application designed for audio engineers to create pro
 ## 🚀 Self Host
 
 ### Prerequisites
+
 - Node.js v16+
 - Supabase account (free tier works)
 
 ### Installation
+
 1. Clone the repository:
    - git clone https://github.com/cj-vana/sounddocs.git
    - cd sounddocs
@@ -80,6 +86,23 @@ SoundDocs is a modern web application designed for audio engineers to create pro
 ## 🤝 Contributing
 
 We welcome any and all contributions! Please join our discord server before making any contributions. discord.gg/hVk6tctuHM
+
+### Local Development
+
+Getting set up for local development is currently a _tad_ convoluted. There's an [issue to make it better](https://github.com/SoundDocs/sounddocs/issues/16).
+
+Assuming you're on a Mac:
+
+- Install either Docker Desktop or OrbStack if you don't have it already
+- Install Homebrew (https://brew.sh/) if you don't have it already
+- Install nvm (`brew install nvm`) if you don't have it already
+- Install Node.js LTS Iron (`nvm install --lts=iron`)
+- Clone the codebase (`git clone https://github.com/SoundDocs/sounddocs.git`)
+- `cd` into that directory
+- Ensure you're using Node.js LTS Iron (`nvm use --lts=iron`)
+- Run `npm install`
+- Start Supabase locally using `npm run local-db`
+- Start the app locally using `npm run dev`
 
 ## 📄 License
 

--- a/bin/injecting-supabase-env
+++ b/bin/injecting-supabase-env
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Work out where this script is being run from, and where the application root is.
+CURRENT_PATH=$(pwd)
+APPLICATION_ROOT_PATH=$(dirname $(dirname $(readlink -f $0)))
+
+# Supabase's CLI only works in the root of the project, so we need to cd to that.
+cd $APPLICATION_ROOT_PATH
+
+# This is kinda dodgy – we just `eval` the output of `supabase status --output env`, which should give us a bunch of env
+# vars related to Supabase. We prefix each one with `SUPABASE_` via some sed trickery to ensure that we don't
+# accidentally override any existing env vars.
+echo "Retrieving Supabase environment variables..."
+eval $(npx supabase status --output env | sed "s/^/SUPABASE_/")
+echo
+
+# Now we've got what we need, we can cd back to wherever the script was run from.
+cd $CURRENT_PATH
+
+# This exposes the Supabase env vars we're interested in to our app, via Vite's `import.meta.env` object.
+export VITE_SUPABASE_URL=$SUPABASE_API_URL
+export VITE_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+
+# Run whatever command was passed to this script.
+echo "Running command: $@"
+eval "$@"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "./bin/injecting-supabase-env vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "local-db": "npx supabase start"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.38.2",


### PR DESCRIPTION
This adds a simple Bash script that ensures the relevant Supabase environment variables are set from the local Supabase DB when running `npm run dev`, meaning one doesn't have to dick around manually setting them.

It also adds a `npm run local-db` script to start up Supabase in case you forget the magic incantation.

One day, someone could make both of these things run one after the other, and a whole new nadir of developer productivity will be reached.