### PR TITLE
fix(lens-calculator): resolve input handling issues with string-based state

### DIFF
--- a/apps/web/src/components/lens-calculator/LensCalculatorV2Enhanced.tsx
+++ b/apps/web/src/components/lens-calculator/LensCalculatorV2Enhanced.tsx
@@ -109,6 +109,15 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
   const [screenGain, setScreenGain] = useState(1.0);
   const [aspectRatioIndex, setAspectRatioIndex] = useState(0);
 
+  // String inputs for better UX
+  const [screenWidthInput, setScreenWidthInput] = useState("");
+  const [screenHeightInput, setScreenHeightInput] = useState("");
+  const [projectorDistanceInput, setProjectorDistanceInput] = useState("");
+  const [distanceToleranceInput, setDistanceToleranceInput] = useState("");
+  const [screenGainInput, setScreenGainInput] = useState("");
+  const [vShiftInput, setVShiftInput] = useState("");
+  const [hShiftInput, setHShiftInput] = useState("");
+
   // Enhanced installation constraints
   const [projectorDistance, setProjectorDistance] = useState(25);
   const [distanceTolerance, setDistanceTolerance] = useState(10); // ±10%
@@ -130,6 +139,53 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
   const [activeSection, setActiveSection] = useState<
     "projector" | "screen" | "constraints" | "results"
   >("projector");
+
+  // Sync string inputs with numeric values on initialization and unit changes
+  useEffect(() => {
+    setScreenWidthInput(
+      screenWidth === 0
+        ? ""
+        : convertFromInches(screenWidth, screenUnit).toFixed(screenUnit === "mm" ? 0 : 1),
+    );
+    setScreenHeightInput(
+      screenHeight === 0
+        ? ""
+        : convertFromInches(screenHeight, screenUnit).toFixed(screenUnit === "mm" ? 0 : 1),
+    );
+  }, [screenUnit]);
+
+  useEffect(() => {
+    setProjectorDistanceInput(projectorDistance === 0 ? "" : projectorDistance.toString());
+  }, [projectorDistance]);
+
+  useEffect(() => {
+    setDistanceToleranceInput(distanceTolerance === 0 ? "" : distanceTolerance.toString());
+  }, [distanceTolerance]);
+
+  useEffect(() => {
+    setScreenGainInput(screenGain.toString());
+  }, [screenGain]);
+
+  useEffect(() => {
+    setVShiftInput(requiredVShift === 0 ? "" : requiredVShift.toString());
+  }, [requiredVShift]);
+
+  useEffect(() => {
+    setHShiftInput(requiredHShift === 0 ? "" : requiredHShift.toString());
+  }, [requiredHShift]);
+
+  // Initialize string inputs on mount
+  useEffect(() => {
+    setScreenWidthInput(
+      convertFromInches(screenWidth, screenUnit).toFixed(screenUnit === "mm" ? 0 : 1),
+    );
+    setScreenHeightInput(
+      convertFromInches(screenHeight, screenUnit).toFixed(screenUnit === "mm" ? 0 : 1),
+    );
+    setProjectorDistanceInput(projectorDistance.toString());
+    setDistanceToleranceInput(distanceTolerance.toString());
+    setScreenGainInput(screenGain.toString());
+  }, []);
 
   // Auto-save calculation state to localStorage for professional workflow
   useEffect(() => {
@@ -1060,6 +1116,16 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                     );
                     setScreenWidth(Math.round(width));
                     setScreenHeight(Math.round(height));
+                    setScreenWidthInput(
+                      convertFromInches(Math.round(width), screenUnit).toFixed(
+                        screenUnit === "mm" ? 0 : 1,
+                      ),
+                    );
+                    setScreenHeightInput(
+                      convertFromInches(Math.round(height), screenUnit).toFixed(
+                        screenUnit === "mm" ? 0 : 1,
+                      ),
+                    );
                   }
                 }}
                 className="w-full px-3 py-2 bg-gray-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
@@ -1088,12 +1154,33 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                         );
                         setScreenWidth(Math.round(width));
                         setScreenHeight(Math.round(height));
+                        setScreenWidthInput(
+                          convertFromInches(Math.round(width), screenUnit).toFixed(
+                            screenUnit === "mm" ? 0 : 1,
+                          ),
+                        );
+                        setScreenHeightInput(
+                          convertFromInches(Math.round(height), screenUnit).toFixed(
+                            screenUnit === "mm" ? 0 : 1,
+                          ),
+                        );
                       }
                     } else if (preset.width) {
                       setScreenWidth(preset.width);
                       const ratio = ASPECT_RATIOS[aspectRatioIndex];
                       if (ratio.width > 0 && ratio.height > 0) {
-                        setScreenHeight(Math.round((preset.width * ratio.height) / ratio.width));
+                        const newHeight = Math.round((preset.width * ratio.height) / ratio.width);
+                        setScreenHeight(newHeight);
+                        setScreenWidthInput(
+                          convertFromInches(preset.width, screenUnit).toFixed(
+                            screenUnit === "mm" ? 0 : 1,
+                          ),
+                        );
+                        setScreenHeightInput(
+                          convertFromInches(newHeight, screenUnit).toFixed(
+                            screenUnit === "mm" ? 0 : 1,
+                          ),
+                        );
                       }
                     }
                   }
@@ -1149,19 +1236,16 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
               <input
                 type="number"
                 step={screenUnit === "mm" ? "1" : "0.1"}
-                value={
-                  screenWidth === 0
-                    ? ""
-                    : convertFromInches(screenWidth, screenUnit).toFixed(
-                        screenUnit === "mm" ? 0 : 1,
-                      )
-                }
+                value={screenWidthInput}
                 onChange={(e) => {
-                  const value = e.target.value.trim();
-                  if (value === "" || value === "0") {
+                  const value = e.target.value;
+                  setScreenWidthInput(value);
+
+                  if (value === "") {
                     setScreenWidth(0);
                     return;
                   }
+
                   const numValue = parseFloat(value);
                   if (!isNaN(numValue) && numValue >= 0) {
                     const valueInInches = convertToInches(numValue, screenUnit);
@@ -1171,21 +1255,13 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                       if (ratio.width > 0 && ratio.height > 0) {
                         const newHeight = (valueInInches * ratio.height) / ratio.width;
                         setScreenHeight(newHeight);
+                        setScreenHeightInput(
+                          convertFromInches(newHeight, screenUnit).toFixed(
+                            screenUnit === "mm" ? 0 : 1,
+                          ),
+                        );
                       }
                     }
-                  }
-                }}
-                onKeyDown={(e) => {
-                  // Allow backspace, delete, tab, escape, enter, and arrow keys
-                  if (
-                    [8, 9, 27, 13, 37, 38, 39, 40, 46].includes(e.keyCode) ||
-                    // Allow Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X
-                    (e.keyCode === 65 && e.ctrlKey) ||
-                    (e.keyCode === 67 && e.ctrlKey) ||
-                    (e.keyCode === 86 && e.ctrlKey) ||
-                    (e.keyCode === 88 && e.ctrlKey)
-                  ) {
-                    return;
                   }
                 }}
                 placeholder="Enter width"
@@ -1201,19 +1277,16 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
               <input
                 type="number"
                 step={screenUnit === "mm" ? "1" : "0.1"}
-                value={
-                  screenHeight === 0
-                    ? ""
-                    : convertFromInches(screenHeight, screenUnit).toFixed(
-                        screenUnit === "mm" ? 0 : 1,
-                      )
-                }
+                value={screenHeightInput}
                 onChange={(e) => {
-                  const value = e.target.value.trim();
-                  if (value === "" || value === "0") {
+                  const value = e.target.value;
+                  setScreenHeightInput(value);
+
+                  if (value === "") {
                     setScreenHeight(0);
                     return;
                   }
+
                   const numValue = parseFloat(value);
                   if (!isNaN(numValue) && numValue >= 0) {
                     const valueInInches = convertToInches(numValue, screenUnit);
@@ -1223,21 +1296,13 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                       if (ratio.width > 0 && ratio.height > 0) {
                         const newWidth = (valueInInches * ratio.width) / ratio.height;
                         setScreenWidth(newWidth);
+                        setScreenWidthInput(
+                          convertFromInches(newWidth, screenUnit).toFixed(
+                            screenUnit === "mm" ? 0 : 1,
+                          ),
+                        );
                       }
                     }
-                  }
-                }}
-                onKeyDown={(e) => {
-                  // Allow backspace, delete, tab, escape, enter, and arrow keys
-                  if (
-                    [8, 9, 27, 13, 37, 38, 39, 40, 46].includes(e.keyCode) ||
-                    // Allow Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X
-                    (e.keyCode === 65 && e.ctrlKey) ||
-                    (e.keyCode === 67 && e.ctrlKey) ||
-                    (e.keyCode === 86 && e.ctrlKey) ||
-                    (e.keyCode === 88 && e.ctrlKey)
-                  ) {
-                    return;
                   }
                 }}
                 placeholder="Enter height"
@@ -1252,8 +1317,21 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                 min="0.1"
                 max="10"
                 step="0.1"
-                value={screenGain}
-                onChange={(e) => setScreenGain(parseFloat(e.target.value) || 1.0)}
+                value={screenGainInput}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setScreenGainInput(value);
+
+                  if (value === "") {
+                    setScreenGain(1.0);
+                    return;
+                  }
+
+                  const numValue = parseFloat(value);
+                  if (!isNaN(numValue) && numValue >= 0.1 && numValue <= 10) {
+                    setScreenGain(numValue);
+                  }
+                }}
                 className="w-full px-3 py-2 bg-gray-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </div>
@@ -1303,29 +1381,19 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                 min="1"
                 max="200"
                 step="0.1"
-                value={projectorDistance || ""}
+                value={projectorDistanceInput}
                 onChange={(e) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
+                  setProjectorDistanceInput(value);
+
                   if (value === "") {
                     setProjectorDistance(0);
                     return;
                   }
+
                   const numValue = parseFloat(value);
                   if (!isNaN(numValue) && numValue >= 0) {
                     setProjectorDistance(numValue);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  // Allow backspace, delete, tab, escape, enter, and arrow keys
-                  if (
-                    [8, 9, 27, 13, 37, 38, 39, 40, 46].includes(e.keyCode) ||
-                    // Allow Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X
-                    (e.keyCode === 65 && e.ctrlKey) ||
-                    (e.keyCode === 67 && e.ctrlKey) ||
-                    (e.keyCode === 86 && e.ctrlKey) ||
-                    (e.keyCode === 88 && e.ctrlKey)
-                  ) {
-                    return;
                   }
                 }}
                 placeholder="Enter distance"
@@ -1342,29 +1410,19 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                 min="0"
                 max="50"
                 step="1"
-                value={distanceTolerance || ""}
+                value={distanceToleranceInput}
                 onChange={(e) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
+                  setDistanceToleranceInput(value);
+
                   if (value === "") {
                     setDistanceTolerance(0);
                     return;
                   }
+
                   const numValue = parseInt(value);
                   if (!isNaN(numValue) && numValue >= 0) {
                     setDistanceTolerance(numValue);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  // Allow backspace, delete, tab, escape, enter, and arrow keys
-                  if (
-                    [8, 9, 27, 13, 37, 38, 39, 40, 46].includes(e.keyCode) ||
-                    // Allow Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X
-                    (e.keyCode === 65 && e.ctrlKey) ||
-                    (e.keyCode === 67 && e.ctrlKey) ||
-                    (e.keyCode === 86 && e.ctrlKey) ||
-                    (e.keyCode === 88 && e.ctrlKey)
-                  ) {
-                    return;
                   }
                 }}
                 placeholder="0"
@@ -1407,31 +1465,19 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                 min="-100"
                 max="100"
                 step="1"
-                value={requiredVShift || ""}
+                value={vShiftInput}
                 onChange={(e) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
+                  setVShiftInput(value);
+
                   if (value === "") {
                     setRequiredVShift(0);
                     return;
                   }
+
                   const numValue = parseInt(value);
                   if (!isNaN(numValue)) {
                     setRequiredVShift(numValue);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  // Allow backspace, delete, tab, escape, enter, and arrow keys
-                  if (
-                    [8, 9, 27, 13, 37, 38, 39, 40, 46].includes(e.keyCode) ||
-                    // Allow Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X, minus sign
-                    (e.keyCode === 65 && e.ctrlKey) ||
-                    (e.keyCode === 67 && e.ctrlKey) ||
-                    (e.keyCode === 86 && e.ctrlKey) ||
-                    (e.keyCode === 88 && e.ctrlKey) ||
-                    e.keyCode === 189 ||
-                    e.keyCode === 109
-                  ) {
-                    return;
                   }
                 }}
                 placeholder="0"
@@ -1448,31 +1494,19 @@ const LensCalculatorV2Enhanced: React.FC<LensCalculatorV2EnhancedProps> = ({ onS
                 min="-100"
                 max="100"
                 step="1"
-                value={requiredHShift || ""}
+                value={hShiftInput}
                 onChange={(e) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
+                  setHShiftInput(value);
+
                   if (value === "") {
                     setRequiredHShift(0);
                     return;
                   }
+
                   const numValue = parseInt(value);
                   if (!isNaN(numValue)) {
                     setRequiredHShift(numValue);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  // Allow backspace, delete, tab, escape, enter, and arrow keys
-                  if (
-                    [8, 9, 27, 13, 37, 38, 39, 40, 46].includes(e.keyCode) ||
-                    // Allow Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X, minus sign
-                    (e.keyCode === 65 && e.ctrlKey) ||
-                    (e.keyCode === 67 && e.ctrlKey) ||
-                    (e.keyCode === 86 && e.ctrlKey) ||
-                    (e.keyCode === 88 && e.ctrlKey) ||
-                    e.keyCode === 189 ||
-                    e.keyCode === 109
-                  ) {
-                    return;
                   }
                 }}
                 placeholder="0"


### PR DESCRIPTION
  - Replace direct numeric input values with string-based input state to prevent typing interference
  - Add separate string states for all numeric inputs (screenWidthInput, projectorDistanceInput, etc.)
  - Sync string inputs with numeric values via useEffect hooks
  - Update aspect ratio and preset handlers to maintain both string and numeric state
  - Fix issues where typing multi-digit numbers would get cut off or formatted prematurely
  - Resolve problems with select-all, backspace, and entering "0" values

   Now users can type naturally without interference from toFixed() formatting during input.